### PR TITLE
依存ライブラリを最新に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Eclipseまたはコンソールでサーバを立ち上げた後、testパッケ
 
 ### 配布用jarの作成
 
-Spring BootではFat Jar(ライブラリなども内包するjar)を作成する事で単一の配布ファイルでアプリケーションを実行することができます。
+Spring Boot では Executable Jar ( ライブラリなども内包するjar ) を作成する事で単一の配布ファイルでアプリケーションを実行することができます。
 
 1. コンソールから「gradlew build」を実行
 1. `build/libs`直下にjarが出力されるのでJava8以降の実行環境へ配布

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,14 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.3.0.RELEASE"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.3.1.RELEASE"
     }
 }
 
 apply plugin: "java"
 apply plugin: "spring-boot"
 
-version = "1.0.0"
+version = "1.0.1"
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
@@ -37,12 +37,13 @@ dependencies {
     compile "org.springframework.boot:spring-boot-starter-aop"
     compile "org.springframework.boot:spring-boot-starter-cache"
     compile "org.springframework.boot:spring-boot-starter-web"
-    compile "org.springframework:spring-orm:4.2.3.RELEASE"
-    compile "org.hibernate:hibernate-core:5.0.3.Final"
-    compile "org.hibernate:hibernate-java8:5.0.3.Final"
-    compile "org.hibernate:hibernate-ehcache:5.0.3.Final"
+    compile "org.springframework:spring-orm:4.2.4.RELEASE"
+    compile "org.hibernate:hibernate-core:5.0.6.Final"
+    compile "org.hibernate:hibernate-java8:5.0.6.Final"
+    compile "org.hibernate:hibernate-ehcache:5.0.6.Final"
+    compile "org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:1.0.0.Final"
     compile "net.sf.ehcache:ehcache-core:2.6.+"
-    compile "com.zaxxer:HikariCP:2.3.+"
+    compile "com.zaxxer:HikariCP:2.4.+"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:2.6.+"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.6.+"
     compile "commons-io:commons-io:2.4"
@@ -55,7 +56,7 @@ dependencies {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = "2.9"
+    gradleVersion = "2.10"
 }
 
 // 自分のプロジェクトとしてディープコピーしたい時は以下の変数を編集した後

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip


### PR DESCRIPTION
- Gradle 2.9 -> 2.10
- Spring Boot 1.3.0 -> 1.3.1
- Hibernate 5.0.3 -> 5.0.6

HibernateORM のバージョンアップに伴ってだと思いますが、クラス互換絡みのエラーが発生したので以下のAPIライブラリを追加して対応しました。

- jboss-transaction-api_1.2_spec
